### PR TITLE
feat: JWT 기반 인증 구현 및 토큰 저장, 자동 재발급 로직 추가

### DIFF
--- a/src/pages/auth/OAuthRedirect.tsx
+++ b/src/pages/auth/OAuthRedirect.tsx
@@ -1,15 +1,25 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { setAccessToken } from "@/services/auth";
 
 const OAuthRedirect = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // console.log("현재 URL:", window.location.href);
-    // console.log("query string:", location.search);
-
     const params = new URLSearchParams(location.search);
-    console.log("error param:", params.get("error"));
+
+    const accessToken = params.get("accessToken");
+    const error = params.get("error");
+
+    if (error) {
+      console.error("OAuth 로그인 오류:", error);
+      navigate("/");
+      return;
+    }
+
+    if (accessToken) {
+      setAccessToken(accessToken);
+    }
 
     navigate("/");
   }, []);

--- a/src/services/api.tsx
+++ b/src/services/api.tsx
@@ -1,3 +1,5 @@
+import { getAccessToken, reissueToken, clearAccessToken } from "./auth";
+
 interface ApiParams {
   apiUrl: string;
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -8,13 +10,10 @@ interface ApiParams {
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-const request = async ({
-  apiUrl,
-  method = "GET",
-  params,
-  body,
-  responseType = "json",
-}: ApiParams) => {
+const request = async (
+  { apiUrl, method = "GET", params, body, responseType = "json" }: ApiParams,
+  retry = true,
+) => {
   let url = API_BASE_URL + apiUrl;
 
   if (params) {
@@ -22,14 +21,28 @@ const request = async ({
     url += `?${query}`;
   }
 
+  const accessToken = getAccessToken();
+
   const response = await fetch(url, {
     method,
     headers: {
       "Content-Type": "application/json",
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
     credentials: "include",
   });
+
+  if (response.status === 401 && retry) {
+    const newAccessToken = await reissueToken();
+
+    if (!newAccessToken) {
+      clearAccessToken();
+      throw new Error("인증이 만료되었습니다. 다시 로그인해주세요.");
+    }
+
+    return request({ apiUrl, method, params, body, responseType }, false);
+  }
 
   if (!response.ok) {
     throw new Error(`API Error: ${response.status}`);
@@ -40,6 +53,7 @@ const request = async ({
 
   return response.json();
 };
+
 export const fetchDataFromApiGet = async ({
   apiUrl,
   params,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,9 +1,47 @@
 import { OAUTH_URL } from "./url.ts";
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const ACCESS_TOKEN_KEY = "accessToken";
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
+
+export const setAccessToken = (accessToken: string) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+};
+
+export const clearAccessToken = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+};
 
 export const loginWithNaver = () => {
   window.location.href = `${API_BASE_URL}${OAUTH_URL.NAVER_LOGIN}`;
 };
 
-// env파일 관련 로그
-// console.log(import.meta.env);
+export const reissueToken = async (): Promise<string | null> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}${OAUTH_URL.REISSUE}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      clearAccessToken();
+      return null;
+    }
+
+    const data = await response.json();
+    const newAccessToken: string = data.accessToken ?? data.data?.accessToken;
+
+    if (newAccessToken) {
+      setAccessToken(newAccessToken);
+    }
+
+    return newAccessToken ?? null;
+  } catch {
+    clearAccessToken();
+    return null;
+  }
+};

--- a/src/services/url.ts
+++ b/src/services/url.ts
@@ -4,6 +4,7 @@ export const OAUTH_URL = {
   //   GOOGLE_LOGIN: "",
   LOGOUT: "/api/auth/logout",
   PHONE: "/api/auth/phone",
+  REISSUE: "/api/auth/reissue",
 };
 
 export const API_URL = {


### PR DESCRIPTION
## 📌 Summary

JWT 기반 인증 처리 구현 및 우선순위 선택 UI 개선

- 네이버 OAuth 로그인 후 Access Token 저장 및 Refresh Token 자동 재발급 로직 추가
- 우선순위 선택 상태를 Record에서 배열로 교체하여 인덱스 자동 정렬 구현
- 맞춤 추천 보기 버튼 중복 클릭 방지 처리

## 🔧 Changes

주요 변경 사항

- `auth.ts`: Access Token 저장/조회/삭제 및 `reissueToken()` 함수 추가
- `api.tsx`: 모든 요청에 `Authorization: Bearer` 헤더 자동 주입, 401 응답 시 토큰 재발급 후 1회 재시도 인터셉터 추가
- `OAuthRedirect.tsx`: OAuth 콜백에서 URL 파라미터의 Access Token 파싱 후 저장 (Refresh Token은 백엔드 HttpOnly 쿠키로 관리)
- `url.ts`: `/api/auth/reissue` 엔드포인트 상수 추가
- `Step3.tsx`: 우선순위 상태 타입 `Record<number, string>` → `string[]` 교체, 항목 제거 시 `filter`로 인덱스 자동 정렬
- `Step3.tsx`: 맞춤 추천 보기 버튼 로딩 중 `disabled` 처리로 중복 제출 방지
