### PR TITLE
Refactor/overlay

### DIFF
--- a/src/components/Info/InfoAmenities.tsx
+++ b/src/components/Info/InfoAmenities.tsx
@@ -78,9 +78,9 @@ const InfoAmenities = ({
   onAmenityItemClick,
 }: AmenitiesProps) => {
   return (
-    <section className="px-5">
+    <section>
       <div className="mb-5">
-        <h2 className="text-lg font-semibold text-coolNeutral-10">
+        <h2 className="px-5 text-lg font-semibold text-coolNeutral-10">
           {title}의 편의시설 수
         </h2>
       </div>
@@ -112,7 +112,7 @@ const AmenityItem = ({
     <button
       type="button"
       onClick={onClick}
-      className={`flex w-full items-center gap-[15px] bg-white px-[18px] py-[15px] text-left transition-colors hover:bg-coolNeutral-99 disabled:hover:bg-white ${
+      className={`flex w-full items-center gap-[15px] bg-white px-[36px] py-[15px] text-left transition-colors hover:bg-coolNeutral-99 disabled:hover:bg-white ${
         isSelected ? "bg-coolNeutral-99" : ""
       }`}
       disabled={!onClick}
@@ -147,7 +147,7 @@ const AmenityList = ({
   onAmenityItemClick?: (item: InfoAmenityItem) => void;
 }) => {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col ">
       {items.map((amenity, index) => {
         const style = amenityStyleMap[amenity.title] ?? defaultAmenityStyle;
 

--- a/src/components/Info/StationIndexPanel.tsx
+++ b/src/components/Info/StationIndexPanel.tsx
@@ -52,6 +52,22 @@ const getDistrictId = (
   return matchedDistrict?.id;
 };
 
+const getDistrictIndexItem = (
+  item: SubwayRankingClickItem,
+  districtIndexes: SubwayIndexDistrictItem[],
+) => {
+  const districtId = getDistrictId(item, districtIndexes);
+
+  return (
+    districtIndexes.find((district) => district.id === districtId) ??
+    districtIndexes.find(
+      (district) =>
+        normalizeDistrictName(district.name) ===
+        normalizeDistrictName(item.name),
+    )
+  );
+};
+
 const groupStationsByLine = (
   stations: DistrictSubwayStation[],
   subwayLines: string[],
@@ -98,6 +114,9 @@ const StationIndexPanel = () => {
   const clearSubwayIndexMapItems = useMapOverlayStore(
     (state) => state.clearSubwayIndexItems,
   );
+  const selectSubwayIndexMapItem = useMapOverlayStore(
+    (state) => state.selectSubwayIndexItem,
+  );
 
   useEffect(() => {
     let isCancelled = false;
@@ -139,6 +158,15 @@ const StationIndexPanel = () => {
 
   const handleDistrictClick = async (item: SubwayRankingClickItem) => {
     const districtId = getDistrictId(item, data.districtIndexes);
+    const districtIndexItem = getDistrictIndexItem(item, data.districtIndexes);
+
+    selectSubwayIndexMapItem(
+      districtIndexItem ?? {
+        id: districtId ?? 0,
+        name: item.name,
+        value: item.value,
+      },
+    );
 
     setStationIndexDetail({
       districtName: item.name,

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -46,8 +46,10 @@ import {
   selectRentIndexItemOnMap,
 } from "@/components/mapOverlays/rentIndexOverlay";
 import {
+  clearSelectedSubwayIndexDistrictPolygons as clearSelectedSubwayIndexDistrictPolygonRefs,
   clearSubwayIndexOverlays as clearSubwayIndexOverlayRefs,
   drawSubwayIndexOverlays,
+  selectSubwayIndexItemOnMap,
 } from "@/components/mapOverlays/subwayIndexOverlay";
 import {
   createPolygonPaths,
@@ -134,6 +136,7 @@ const Map = ({ enableOverlay = true }: Props) => {
   const basicPolygonsRef = useRef<any[]>([]);
   const rentIndexOverlaysRef = useRef<any[]>([]);
   const subwayIndexOverlaysRef = useRef<any[]>([]);
+  const selectedSubwayIndexDistrictPolygonsRef = useRef<any[]>([]);
   const safetyIndexOverlaysRef = useRef<any[]>([]);
   const selectedSafetyDistrictPolygonsRef = useRef<any[]>([]);
   const selectedHomeRecommendationPolygonsRef = useRef<any[]>([]);
@@ -154,6 +157,9 @@ const Map = ({ enableOverlay = true }: Props) => {
   );
   const subwayIndexItems = useMapOverlayStore(
     (state) => state.subwayIndexItems,
+  );
+  const selectedSubwayIndexItem = useMapOverlayStore(
+    (state) => state.selectedSubwayIndexItem,
   );
   const safetyIndexItems = useMapOverlayStore(
     (state) => state.safetyIndexItems,
@@ -193,6 +199,12 @@ const Map = ({ enableOverlay = true }: Props) => {
 
   const clearSubwayIndexOverlays = () => {
     clearSubwayIndexOverlayRefs(subwayIndexOverlaysRef.current);
+  };
+
+  const clearSelectedSubwayIndexDistrictPolygons = () => {
+    clearSelectedSubwayIndexDistrictPolygonRefs(
+      selectedSubwayIndexDistrictPolygonsRef.current,
+    );
   };
 
   const clearSafetyIndexOverlays = () => {
@@ -331,8 +343,29 @@ const Map = ({ enableOverlay = true }: Props) => {
 
     return () => {
       clearSubwayIndexOverlays();
+      clearSelectedSubwayIndexDistrictPolygons();
     };
   }, [isMapReady, subwayIndexItems]);
+
+  useEffect(() => {
+    if (!isMapReady || !mapRefInstance.current) return;
+
+    if (!selectedSubwayIndexItem) {
+      clearSelectedSubwayIndexDistrictPolygons();
+      return;
+    }
+
+    selectSubwayIndexItemOnMap({
+      map: mapRefInstance.current,
+      item: selectedSubwayIndexItem,
+      districtCenters,
+      selectedPolygonRefs: selectedSubwayIndexDistrictPolygonsRef.current,
+    });
+
+    return () => {
+      clearSelectedSubwayIndexDistrictPolygons();
+    };
+  }, [isMapReady, selectedSubwayIndexItem]);
 
   useEffect(() => {
     if (!isMapReady || !mapRefInstance.current) return;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -28,6 +28,7 @@ import {
   clearSubwayStationMarkers,
   drawSubwayLinePolylines,
   drawSubwayStationMarkers,
+  selectSubwayStationMarkerOnMap,
 } from "@/components/mapOverlays/subwayOverlay";
 import {
   clearHomeSubwayDistrictOverlay,
@@ -440,6 +441,11 @@ const Map = ({ enableOverlay = true }: Props) => {
 
     mapRefInstance.current.setLevel(4);
     mapRefInstance.current.panTo(position);
+    selectSubwayStationMarkerOnMap({
+      map: mapRefInstance.current,
+      marker: selectedSubwayStationMarker,
+      markerRefs: subwayStationMarkerRefs.current,
+    });
   }, [isMapReady, selectedSubwayStationMarker]);
 
   useEffect(() => {

--- a/src/components/community/CommunityList.tsx
+++ b/src/components/community/CommunityList.tsx
@@ -35,9 +35,14 @@ const CommunityList = ({ onWriteClick, onPostClick }: CommunityListProps) => {
     loadPosts();
   }, [activeTab]);
 
-  const filteredPosts = search.trim()
-    ? posts.filter((p) => p.neighborhoodName?.includes(search.trim()))
-    : posts;
+  const filteredPosts = posts.filter((post) => {
+    const matchesCategory = post.category === activeTab;
+    const matchesSearch = search.trim()
+      ? post.neighborhoodName?.includes(search.trim())
+      : true;
+
+    return matchesCategory && matchesSearch;
+  });
 
   return (
     <div className="relative flex flex-col flex-shrink-0 w-full h-full bg-white border-r border-gray-100">
@@ -115,14 +120,13 @@ const CommunityList = ({ onWriteClick, onPostClick }: CommunityListProps) => {
               : "게시글이 없습니다."}
           </div>
         ) : (
-          filteredPosts.map(
-            (post) => (
-                <PostCard
-                  key={post.id}
-                  post={post}
-                  onClick={() => onPostClick(post.id)}
-                />
-            ))
+          filteredPosts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              onClick={() => onPostClick(post.id)}
+            />
+          ))
         )}
       </div>
 
@@ -130,7 +134,7 @@ const CommunityList = ({ onWriteClick, onPostClick }: CommunityListProps) => {
       <div className="absolute z-10 -translate-x-1/2 bottom-20 left-1/2">
         <button
           onClick={onWriteClick}
-          className="flex items-center gap-2 px-6 py-2 text-sm text-coolNeutral-30 font-semibold transition-colors border rounded-full bg-blue-95 border-blue-90 hover:bg-gray-50"
+          className="flex items-center gap-2 px-6 py-2 text-sm font-semibold transition-colors border rounded-full text-coolNeutral-30 bg-blue-95 border-blue-90 hover:bg-gray-50"
         >
           <svg
             className="w-5 h-5 text-blue-500"

--- a/src/components/community/CommunityList.tsx
+++ b/src/components/community/CommunityList.tsx
@@ -4,6 +4,7 @@ import { fetchPosts } from "@/services/communityApi";
 import type { Post } from "@/types/community";
 
 const TABS = [
+  { label: "전체", value: "전체" },
   { label: "추천", value: "추천" },
   { label: "질문", value: "질문" },
   { label: "거주리뷰", value: "거주리뷰" },
@@ -36,7 +37,7 @@ const CommunityList = ({ onWriteClick, onPostClick }: CommunityListProps) => {
   }, [activeTab]);
 
   const filteredPosts = posts.filter((post) => {
-    const matchesCategory = post.category === activeTab;
+    const matchesCategory = activeTab === "전체" || post.category === activeTab;
     const matchesSearch = search.trim()
       ? post.neighborhoodName?.includes(search.trim())
       : true;

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -25,7 +25,7 @@ const PostCard = ({ post, onClick }: PostCardProps) => {
       <p className="mb-1 font-medium text-black text-md opacity-80">
         {post.title}
       </p>
-      <p className="mb-1 text-sm font-Pretendard text-coolNeutral-50">
+      <p className="mb-1 line-clamp-2 text-sm font-Pretendard text-coolNeutral-50">
         {post.content}
       </p>
       <p className="text-xs font-Pretendard text-coolNeutral-70">

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -10,7 +10,7 @@ const PostCard = ({ post, onClick }: PostCardProps) => {
   return (
     <div
       onClick={onClick}
-      className="px-4 py-4 transition-colors border-b border-gray-100 cursor-pointer hover:bg-coolNeutral-99"
+      className="px-5 py-4 transition-colors border-b border-gray-100 cursor-pointer hover:bg-coolNeutral-99"
     >
       <div className="flex flex-wrap gap-1 mb-2 text-coolNeutral-30">
         <span className="text-xs px-1.5 py-1 rounded-full bg-blue-99 border border-blue-70 font-Pretendard">

--- a/src/components/home/HeaderSection.tsx
+++ b/src/components/home/HeaderSection.tsx
@@ -15,6 +15,7 @@ const HeaderSection = () => {
         label="급상승 지역"
         iconWidth="30"
         iconHeight="42"
+        onClick={() => navigate("/info")}
       />
       <IconButton
         icon={RecommendationIcon}

--- a/src/components/mapOverlays/convenienceMarkerOverlay.ts
+++ b/src/components/mapOverlays/convenienceMarkerOverlay.ts
@@ -15,6 +15,13 @@ type KakaoMap = {
 
 type KakaoMarker = {
   setMap: (map: KakaoMap | null) => void;
+  setZIndex?: (zIndex: number) => void;
+  __tooltipOverlay?: KakaoOverlay;
+};
+
+type KakaoOverlay = {
+  setMap: (map: KakaoMap | null) => void;
+  setZIndex?: (zIndex: number) => void;
 };
 
 type DrawConvenienceMarkersParams = {
@@ -39,8 +46,64 @@ const escapeHtml = (value: string) =>
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#039;");
 
+const getConvenienceTooltipContent = (name: string) => `
+  <div
+    style="
+      position: relative;
+      z-index: 2147483647;
+      pointer-events: none;
+      transform: translateY(-8px);
+      padding: 9px 12px;
+      min-width: max-content;
+      max-width: 220px;
+      color: #111827;
+      font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: rgba(255, 255, 255, 0.96);
+      border: 1px solid rgba(17, 24, 39, 0.08);
+      border-radius: 8px;
+      box-shadow: 0 14px 34px rgba(15, 23, 42, 0.18), 0 2px 8px rgba(15, 23, 42, 0.10);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.2;
+      letter-spacing: 0;
+    "
+  >
+    ${escapeHtml(name)}
+    <div
+      style="
+        position: absolute;
+        left: 50%;
+        bottom: -6px;
+        width: 12px;
+        height: 12px;
+        transform: translateX(-50%) rotate(45deg);
+        background: rgba(255, 255, 255, 0.96);
+        border-right: 1px solid rgba(17, 24, 39, 0.08);
+        border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+      "
+    ></div>
+  </div>
+`;
+
+const showConvenienceTooltip = (marker: KakaoMarker, map: KakaoMap) => {
+  marker.setZIndex?.(10001);
+  marker.__tooltipOverlay?.setZIndex?.(10000);
+  marker.__tooltipOverlay?.setMap(map);
+};
+
+const hideConvenienceTooltip = (marker: KakaoMarker) => {
+  marker.setZIndex?.(0);
+  marker.__tooltipOverlay?.setMap(null);
+};
+
 export const clearConvenienceMarkers = (markerRefs: KakaoMarker[]) => {
   markerRefs.forEach((marker) => {
+    hideConvenienceTooltip(marker);
     marker.setMap(null);
   });
   markerRefs.length = 0;
@@ -76,19 +139,23 @@ export const drawConvenienceMarkers = ({
       position,
       title: pin.name,
       image: markerImage,
-    });
-
-    const infoWindow = new window.kakao.maps.InfoWindow({
-      content: `<div style="padding:6px 10px;font-size:12px;white-space:nowrap;">${escapeHtml(pin.name)}</div>`,
+    }) as KakaoMarker;
+    const tooltipOverlay = new window.kakao.maps.CustomOverlay({
+      position,
+      content: getConvenienceTooltipContent(pin.name),
+      xAnchor: 0.5,
+      yAnchor: 1.25,
+      zIndex: 10000,
     });
 
     window.kakao.maps.event.addListener(marker, "mouseover", () => {
-      infoWindow.open(map, marker);
+      showConvenienceTooltip(marker, map);
     });
     window.kakao.maps.event.addListener(marker, "mouseout", () => {
-      infoWindow.close();
+      hideConvenienceTooltip(marker);
     });
 
+    marker.__tooltipOverlay = tooltipOverlay;
     markerRefs.push(marker);
     bounds.extend(position);
   });

--- a/src/components/mapOverlays/rentIndexOverlay.ts
+++ b/src/components/mapOverlays/rentIndexOverlay.ts
@@ -1,6 +1,11 @@
 import seoulGeoJson from "@/assets/geojson/seoul-gu-simple.json";
 import { regionMap } from "@/constants/regionMap";
-import { createPolygonPaths } from "@/components/mapOverlays/geoJson";
+import {
+  createPolygonPaths,
+  getCenterFromLngLatPoints,
+  getGeoJsonLngLatPoints,
+  type GeoJsonLngLatGeometry,
+} from "@/components/mapOverlays/geoJson";
 import type {
   RentIndexMapOverlayItem,
   RentIndexMapOverlayType,
@@ -14,7 +19,7 @@ type KakaoOverlay = {
   setMap: (map: KakaoMap | null) => void;
 };
 
-type KakaoPolygon = {
+type KakaoMapElement = {
   setMap: (map: KakaoMap | null) => void;
 };
 
@@ -38,7 +43,7 @@ type DrawRentIndexOverlaysParams = {
   items: RentIndexMapOverlayItem[];
   regionCenters: globalThis.Map<string, RegionCenter>;
   overlayRefs: KakaoOverlay[];
-  selectedPolygonRefs: KakaoPolygon[];
+  selectedPolygonRefs: KakaoMapElement[];
 };
 
 type SelectRentIndexItemParams = {
@@ -46,12 +51,20 @@ type SelectRentIndexItemParams = {
   item: RentIndexMapOverlayItem;
   regionCenters: globalThis.Map<string, RegionCenter>;
   overlayRefs: KakaoOverlay[];
-  selectedPolygonRefs: KakaoPolygon[];
+  selectedPolygonRefs: KakaoMapElement[];
 };
 
 const getRegionName = (name: string) => {
   return name.split(" ").at(-1) ?? name;
 };
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
 
 const getOverlayColor = (type: RentIndexMapOverlayType) => {
   if (type === "RISE") return "#FF5555";
@@ -104,6 +117,30 @@ const createRentIndexOverlayContent = (
   return button;
 };
 
+const createDistrictNameLabelContent = (
+  districtName: string,
+  color: string,
+) => `
+  <div style="
+    min-width: 54px;
+    padding: 7px 10px;
+    border: 1px solid ${color}33;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.95);
+    color: #111827;
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1.2;
+    letter-spacing: 0;
+    text-align: center;
+    box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16), 0 2px 6px rgba(15, 23, 42, 0.08);
+    white-space: nowrap;
+  ">
+    ${escapeHtml(districtName)}
+  </div>
+`;
+
 export const clearRentIndexOverlays = (overlayRefs: KakaoOverlay[]) => {
   overlayRefs.forEach((overlay) => {
     overlay.setMap(null);
@@ -111,7 +148,9 @@ export const clearRentIndexOverlays = (overlayRefs: KakaoOverlay[]) => {
   overlayRefs.length = 0;
 };
 
-export const clearSelectedRegionPolygons = (polygonRefs: KakaoPolygon[]) => {
+export const clearSelectedRegionPolygons = (
+  polygonRefs: KakaoMapElement[],
+) => {
   polygonRefs.forEach((polygon) => {
     polygon.setMap(null);
   });
@@ -122,7 +161,7 @@ const drawSelectedRegionPolygons = (
   map: KakaoMap,
   regionName: string,
   type: RentIndexMapOverlayType,
-  polygonRefs: KakaoPolygon[],
+  polygonRefs: KakaoMapElement[],
 ) => {
   clearSelectedRegionPolygons(polygonRefs);
 
@@ -132,6 +171,10 @@ const drawSelectedRegionPolygons = (
     const guName = feature.properties.SIG_KOR_NM;
 
     if (regionMap[guName] !== regionName) return;
+
+    const districtCenter = getCenterFromLngLatPoints(
+      getGeoJsonLngLatPoints(feature.geometry as GeoJsonLngLatGeometry),
+    );
 
     const polygons =
       feature.geometry.type === "Polygon"
@@ -152,6 +195,21 @@ const drawSelectedRegionPolygons = (
 
       polygonRefs.push(polygon);
     });
+
+    if (!districtCenter) return;
+
+    const labelOverlay = new window.kakao.maps.CustomOverlay({
+      map,
+      position: new window.kakao.maps.LatLng(
+        districtCenter.lat,
+        districtCenter.lng,
+      ),
+      zIndex: 6,
+      yAnchor: 0.5,
+      content: createDistrictNameLabelContent(guName, fillColor),
+    });
+
+    polygonRefs.push(labelOverlay);
   });
 };
 

--- a/src/components/mapOverlays/subwayIndexOverlay.ts
+++ b/src/components/mapOverlays/subwayIndexOverlay.ts
@@ -1,8 +1,17 @@
+import seoulGeoJson from "@/assets/geojson/seoul-gu-simple.json";
+import { createPolygonPaths } from "@/components/mapOverlays/geoJson";
 import type { SubwayIndexMapOverlayItem } from "@/store/mapOverlayStore";
 
-type KakaoMap = object;
+type KakaoMap = {
+  setCenter?: (position: unknown) => void;
+  setLevel?: (level: number) => void;
+};
 
 type KakaoOverlay = {
+  setMap: (map: KakaoMap | null) => void;
+};
+
+type KakaoPolygon = {
   setMap: (map: KakaoMap | null) => void;
 };
 
@@ -16,6 +25,23 @@ type DrawSubwayIndexOverlaysParams = {
   items: SubwayIndexMapOverlayItem[];
   districtCenters: globalThis.Map<string, DistrictCenter>;
   overlayRefs: KakaoOverlay[];
+};
+
+type SelectSubwayIndexItemOnMapParams = {
+  map: KakaoMap;
+  item: SubwayIndexMapOverlayItem;
+  districtCenters: globalThis.Map<string, DistrictCenter>;
+  selectedPolygonRefs: KakaoPolygon[];
+};
+
+type DistrictGeoJsonFeature = {
+  properties: {
+    SIG_KOR_NM: string;
+  };
+  geometry: {
+    type: "Polygon" | "MultiPolygon";
+    coordinates: number[][][] | number[][][][];
+  };
 };
 
 const getRegionName = (name: string) => {
@@ -69,6 +95,71 @@ export const clearSubwayIndexOverlays = (overlayRefs: KakaoOverlay[]) => {
     overlay.setMap(null);
   });
   overlayRefs.length = 0;
+};
+
+export const clearSelectedSubwayIndexDistrictPolygons = (
+  polygonRefs: KakaoPolygon[],
+) => {
+  polygonRefs.forEach((polygon) => {
+    polygon.setMap(null);
+  });
+  polygonRefs.length = 0;
+};
+
+const drawSelectedSubwayIndexDistrictPolygon = (
+  map: KakaoMap,
+  districtName: string,
+  color: string,
+  polygonRefs: KakaoPolygon[],
+) => {
+  clearSelectedSubwayIndexDistrictPolygons(polygonRefs);
+
+  (seoulGeoJson.features as DistrictGeoJsonFeature[]).forEach((feature) => {
+    const guName = feature.properties.SIG_KOR_NM;
+
+    if (guName !== districtName) return;
+
+    const polygons =
+      feature.geometry.type === "Polygon"
+        ? [feature.geometry.coordinates as number[][][]]
+        : (feature.geometry.coordinates as number[][][][]);
+
+    polygons.forEach((rings) => {
+      const polygon = new window.kakao.maps.Polygon({
+        map,
+        path: createPolygonPaths(rings),
+        strokeWeight: 3,
+        strokeColor: color,
+        strokeOpacity: 1,
+        fillColor: color,
+        fillOpacity: 0.24,
+        zIndex: 5,
+      });
+
+      polygonRefs.push(polygon);
+    });
+  });
+};
+
+export const selectSubwayIndexItemOnMap = ({
+  map,
+  item,
+  districtCenters,
+  selectedPolygonRefs,
+}: SelectSubwayIndexItemOnMapParams) => {
+  const district = getRegionName(item.name);
+  const center = districtCenters.get(district);
+
+  if (!center) return;
+
+  drawSelectedSubwayIndexDistrictPolygon(
+    map,
+    district,
+    getSubwayIndexOverlayColor(item.value),
+    selectedPolygonRefs,
+  );
+  map.setLevel?.(6);
+  map.setCenter?.(new window.kakao.maps.LatLng(center.lat, center.lng));
 };
 
 export const drawSubwayIndexOverlays = ({

--- a/src/components/mapOverlays/subwayOverlay.ts
+++ b/src/components/mapOverlays/subwayOverlay.ts
@@ -12,6 +12,15 @@ type KakaoPolyline = {
 
 type KakaoMarker = {
   setMap: (map: KakaoMap | null) => void;
+  setZIndex?: (zIndex: number) => void;
+  __tooltipOverlay?: KakaoOverlay;
+  __subwayStationMarker?: SubwayStationMarker;
+};
+
+type KakaoOverlay = {
+  setMap: (map: KakaoMap | null) => void;
+  setPosition?: (position: unknown) => void;
+  setZIndex?: (zIndex: number) => void;
 };
 
 type DrawSubwayLinePolylinesParams = {
@@ -23,6 +32,12 @@ type DrawSubwayLinePolylinesParams = {
 type DrawSubwayStationMarkersParams = {
   map: KakaoMap;
   markers: SubwayStationMarker[];
+  markerRefs: KakaoMarker[];
+};
+
+type SelectSubwayStationMarkerOnMapParams = {
+  map: KakaoMap;
+  marker: SubwayStationMarker;
   markerRefs: KakaoMarker[];
 };
 
@@ -45,6 +60,102 @@ const getSubwayStationMarkerImage = (color: string) => {
   return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(markerSvg)}`;
 };
 
+const getSubwayStationTooltipContent = (
+  stationName: string,
+  lineName: string,
+  color: string,
+) => `
+  <div
+    style="
+      position: relative;
+      z-index: 2147483647;
+      pointer-events: none;
+      transform: translateY(-8px);
+      padding: 9px 12px 10px;
+      min-width: max-content;
+      color: #111827;
+      font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: rgba(255, 255, 255, 0.96);
+      border: 1px solid rgba(17, 24, 39, 0.08);
+      border-radius: 8px;
+      box-shadow: 0 14px 34px rgba(15, 23, 42, 0.18), 0 2px 8px rgba(15, 23, 42, 0.10);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      white-space: nowrap;
+    "
+  >
+    <div
+      style="
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 13px;
+        font-weight: 700;
+        line-height: 1.2;
+        letter-spacing: 0;
+      "
+    >
+      <span
+        style="
+          width: 8px;
+          height: 8px;
+          flex: 0 0 auto;
+          border-radius: 999px;
+          background: ${color};
+          box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.06);
+        "
+      ></span>
+      <span>${escapeHtml(stationName)}</span>
+    </div>
+    <div
+      style="
+        margin-top: 4px;
+        padding-left: 15px;
+        color: #6b7280;
+        font-size: 11px;
+        font-weight: 600;
+        line-height: 1.2;
+        letter-spacing: 0;
+      "
+    >
+      ${escapeHtml(lineName)}
+    </div>
+    <div
+      style="
+        position: absolute;
+        left: 50%;
+        bottom: -6px;
+        width: 12px;
+        height: 12px;
+        transform: translateX(-50%) rotate(45deg);
+        background: rgba(255, 255, 255, 0.96);
+        border-right: 1px solid rgba(17, 24, 39, 0.08);
+        border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+      "
+    ></div>
+  </div>
+`;
+
+const isSameSubwayStationMarker = (
+  left: SubwayStationMarker,
+  right: SubwayStationMarker,
+) =>
+  left.stationName === right.stationName &&
+  left.lineName === right.lineName &&
+  left.latitude === right.latitude &&
+  left.longitude === right.longitude;
+
+const showSubwayStationTooltip = (marker: KakaoMarker, map: KakaoMap) => {
+  marker.setZIndex?.(10001);
+  marker.__tooltipOverlay?.setZIndex?.(10000);
+  marker.__tooltipOverlay?.setMap(map);
+};
+
+const hideSubwayStationTooltip = (marker: KakaoMarker) => {
+  marker.setZIndex?.(1000);
+  marker.__tooltipOverlay?.setMap(null);
+};
+
 export const clearSubwayLinePolylines = (polylineRefs: KakaoPolyline[]) => {
   polylineRefs.forEach((polyline) => {
     polyline.setMap(null);
@@ -54,9 +165,27 @@ export const clearSubwayLinePolylines = (polylineRefs: KakaoPolyline[]) => {
 
 export const clearSubwayStationMarkers = (markerRefs: KakaoMarker[]) => {
   markerRefs.forEach((marker) => {
+    hideSubwayStationTooltip(marker);
     marker.setMap(null);
   });
   markerRefs.length = 0;
+};
+
+export const selectSubwayStationMarkerOnMap = ({
+  map,
+  marker,
+  markerRefs,
+}: SelectSubwayStationMarkerOnMapParams) => {
+  markerRefs.forEach((markerRef) => {
+    const stationMarker = markerRef.__subwayStationMarker;
+
+    if (stationMarker && isSameSubwayStationMarker(stationMarker, marker)) {
+      showSubwayStationTooltip(markerRef, map);
+      return;
+    }
+
+    hideSubwayStationTooltip(markerRef);
+  });
 };
 
 export const drawSubwayLinePolylines = ({
@@ -108,21 +237,30 @@ export const drawSubwayStationMarkers = ({
     const subwayStationMarker = new window.kakao.maps.Marker({
       map,
       position,
-      title: marker.stationName,
       image: markerImage,
-      zIndex: 9,
-    });
-    const infoWindow = new window.kakao.maps.InfoWindow({
-      content: `<div style="padding:6px 10px;font-size:12px;white-space:nowrap;">${escapeHtml(marker.stationName)} · ${escapeHtml(marker.lineName)}</div>`,
+      zIndex: 1000,
+    }) as KakaoMarker;
+    const tooltipOverlay = new window.kakao.maps.CustomOverlay({
+      position,
+      content: getSubwayStationTooltipContent(
+        marker.stationName,
+        marker.lineName,
+        color,
+      ),
+      xAnchor: 0.5,
+      yAnchor: 1.25,
+      zIndex: 10000,
     });
 
     window.kakao.maps.event.addListener(subwayStationMarker, "mouseover", () => {
-      infoWindow.open(map, subwayStationMarker);
+      showSubwayStationTooltip(subwayStationMarker, map);
     });
     window.kakao.maps.event.addListener(subwayStationMarker, "mouseout", () => {
-      infoWindow.close();
+      hideSubwayStationTooltip(subwayStationMarker);
     });
 
+    subwayStationMarker.__tooltipOverlay = tooltipOverlay;
+    subwayStationMarker.__subwayStationMarker = marker;
     markerRefs.push(subwayStationMarker);
   });
 };

--- a/src/pages/community/PostDetail.tsx
+++ b/src/pages/community/PostDetail.tsx
@@ -22,7 +22,12 @@ interface PostDetailPageProps {
 const getErrorMessage = (error: unknown, fallback: string) =>
   error instanceof Error ? error.message : fallback;
 
-const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostDetailPageProps) => {
+const PostDetailPage = ({
+  postId,
+  onClose,
+  onEditClick,
+  onDeleteSuccess,
+}: PostDetailPageProps) => {
   const [post, setPost] = useState<PostDetail | null>(null);
   const [liked, setLiked] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
@@ -102,7 +107,7 @@ const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostD
     return (
       <div className="flex flex-col items-center justify-center h-full gap-3 text-sm text-gray-400">
         <p>{error}</p>
-        <button onClick={onClose} className="text-blue-500 text-xs underline">
+        <button onClick={onClose} className="text-xs text-blue-500 underline">
           목록으로 돌아가기
         </button>
       </div>
@@ -113,53 +118,106 @@ const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostD
 
   return (
     <div className="flex flex-col h-full bg-white">
-      {/* 본문 */}
-      <div className="flex-1 overflow-y-auto no-scrollbar px-4 py-4 pt-28">
-        <div className="flex items-center justify-between mb-3">
-            {/* 작성자 정보 */}
-            <div className="flex items-center gap-4 mb-3">
-                <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
-                    <svg className="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                    </svg>
-                </div>
-                <div>
-                    <p className="text-sm font-semibold text-black">{post.userName}</p>
-                    <p className="text-xs text-coolNeutral-70">{formatDateTime(post.createdAt)}</p>
-                </div>
-            </div>
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="상세 닫기"
+          className="text-gray-500 transition-colors hover:text-gray-700"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        <div className="w-5" />
+      </div>
 
-            {/* 수정/삭제 버튼 */}
-                <div className="flex justify-end gap-3 px-3 -mt-5">
-                    <button
-                        onClick={() => onEditClick(postId)}
-                        className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
-                    >
-                        수정
-                    </button>
-                    <button
-                        onClick={handleDelete}
-                        className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
-                    >
-                        삭제
-                    </button>
-                </div>
+      {/* 본문 */}
+      <div className="flex-1 px-4 py-4 overflow-y-auto no-scrollbar">
+        <div className="flex items-center justify-between mb-3">
+          {/* 작성자 정보 */}
+          <div className="flex items-center gap-4 mb-3">
+            <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 bg-blue-100 rounded-full">
+              <svg
+                className="w-4 h-4 text-blue-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-black">
+                {post.userName}
+              </p>
+              <p className="text-xs text-coolNeutral-70">
+                {formatDateTime(post.createdAt)}
+              </p>
+            </div>
+          </div>
+
+          {/* 수정/삭제 버튼 */}
+          <div className="flex justify-end gap-3 px-3 -mt-5">
+            <button
+              onClick={() => onEditClick(postId)}
+              className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
+            >
+              수정
+            </button>
+            <button
+              onClick={handleDelete}
+              className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
+            >
+              삭제
+            </button>
+          </div>
         </div>
 
-
-        <h1 className="text-md font-semibold text-coolNeutral-25 mb-2 leading-snug">{post.title}</h1>
-        <p className="text-sm text-coolNeutral-30 leading-relaxed mb-4 whitespace-pre-line">{post.content}</p>
+        <h1 className="mb-2 font-semibold leading-snug text-md text-coolNeutral-25">
+          {post.title}
+        </h1>
+        <p className="mb-4 text-sm leading-relaxed whitespace-pre-line text-coolNeutral-30">
+          {post.content}
+        </p>
 
         {/* 공감 / 댓글 버튼 */}
         <div className="flex gap-4 mb-8">
           <button
             onClick={handleLike}
             className={`flex items-center gap-1.5 text-sm text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors ${
-              liked ? "text-coolNeutral-25" : "text-coolNeutral-25 hover:text-gray-600"
+              liked
+                ? "text-coolNeutral-25"
+                : "text-coolNeutral-25 hover:text-gray-600"
             }`}
           >
-            <svg className="w-4 h-4" fill={liked ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+            <svg
+              className="w-4 h-4"
+              fill={liked ? "currentColor" : "none"}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+              />
             </svg>
             공감
           </button>
@@ -167,8 +225,18 @@ const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostD
             onClick={() => setShowCommentModal(true)}
             className="flex items-center gap-1.5 text-sm text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+              />
             </svg>
             댓글 남기기
           </button>
@@ -180,40 +248,61 @@ const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostD
         {/* 댓글 목록 */}
         <div>
           {comments.length === 0 ? (
-            <p className="text-md text-coolNeutral-25 text-center py-12">아직 작성된 댓글이 없습니다.</p>
+            <p className="py-12 text-center text-md text-coolNeutral-25">
+              아직 작성된 댓글이 없습니다.
+            </p>
           ) : (
             <div className="space-y-4">
               {comments.map((comment) => (
-                <div key={comment.id} className="border-b border-gray-50 pb-4">
+                <div key={comment.id} className="pb-4 border-b border-gray-50">
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
-                            <svg className="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                            </svg>
-                        </div>
-                        <p className="text-sm font-semibold text-black">{comment.userName}</p>
+                      <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 bg-blue-100 rounded-full">
+                        <svg
+                          className="w-4 h-4 text-blue-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                          />
+                        </svg>
+                      </div>
+                      <p className="text-sm font-semibold text-black">
+                        {comment.userName}
+                      </p>
                     </div>
                     {/* 댓글 삭제  */}
                     <div className="px-3">
-                        <button
-                            onClick={async () => {
-                                if (!window.confirm("댓글을 삭제하시겠습니까?")) return;
-                                try {
-                                    await deleteComment(comment.id);
-                                    setComments((prev) => prev.filter((c) => c.id !== comment.id));
-                                } catch (e: unknown) {
-                                    alert(getErrorMessage(e, "삭제에 실패했습니다."));
-                                }
-                            }}
-                            className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
-                        >
-                            삭제
-                        </button>
+                      <button
+                        onClick={async () => {
+                          if (!window.confirm("댓글을 삭제하시겠습니까?"))
+                            return;
+                          try {
+                            await deleteComment(comment.id);
+                            setComments((prev) =>
+                              prev.filter((c) => c.id !== comment.id),
+                            );
+                          } catch (e: unknown) {
+                            alert(getErrorMessage(e, "삭제에 실패했습니다."));
+                          }
+                        }}
+                        className="flex items-center gap-1.5 text-xs text-coolNeutral-25 bg-blue-99 border border-blue-95 rounded-lg px-2.5 py-1 transition-colors"
+                      >
+                        삭제
+                      </button>
                     </div>
-                </div>
-                  <p className="text-sm text-gray-600 leading-relaxed">{comment.content}</p>
-                  <p className="text-xs text-gray-400 mt-2">{formatDateTime(comment.createdAt)}</p>
+                  </div>
+                  <p className="text-sm leading-relaxed text-gray-600">
+                    {comment.content}
+                  </p>
+                  <p className="mt-2 text-xs text-gray-400">
+                    {formatDateTime(comment.createdAt)}
+                  </p>
                 </div>
               ))}
             </div>
@@ -222,18 +311,19 @@ const PostDetailPage = ({ postId, onClose, onEditClick, onDeleteSuccess }: PostD
       </div>
 
       {/* 댓글 모달 */}
-      {showCommentModal && createPortal(
-        <CommentModal
-          postId={String(postId)}
-          userName={currentUser?.name ?? ""}
-          onClose={() => setShowCommentModal(false)}
-          onSubmit={async () => {
-            await loadComments();
-            setShowCommentModal(false);
-          }}
-        />,
-        document.body
-      )}
+      {showCommentModal &&
+        createPortal(
+          <CommentModal
+            postId={String(postId)}
+            userName={currentUser?.name ?? ""}
+            onClose={() => setShowCommentModal(false)}
+            onSubmit={async () => {
+              await loadComments();
+              setShowCommentModal(false);
+            }}
+          />,
+          document.body,
+        )}
     </div>
   );
 };

--- a/src/store/mapOverlayStore.ts
+++ b/src/store/mapOverlayStore.ts
@@ -69,6 +69,7 @@ type MapOverlayStore = {
   selectedRentIndexItem: RentIndexMapOverlayItem | null;
   consumerIndexItem: ConsumerIndexMapOverlayItem | null;
   subwayIndexItems: SubwayIndexMapOverlayItem[];
+  selectedSubwayIndexItem: SubwayIndexMapOverlayItem | null;
   safetyIndexItems: SafetyIndexMapOverlayItem[];
   selectedHomeRecommendationName: string | null;
   selectedHomeSubwayRanking: HomeSubwayRankingMapItem | null;
@@ -84,6 +85,7 @@ type MapOverlayStore = {
   setConsumerIndexItem: (item: ConsumerIndexMapOverlayItem) => void;
   clearConsumerIndexItem: () => void;
   setSubwayIndexItems: (items: SubwayIndexMapOverlayItem[]) => void;
+  selectSubwayIndexItem: (item: SubwayIndexMapOverlayItem) => void;
   clearSubwayIndexItems: () => void;
   setSafetyIndexItems: (items: SafetyIndexMapOverlayItem[]) => void;
   clearSafetyIndexItems: () => void;
@@ -111,6 +113,7 @@ export const useMapOverlayStore = create<MapOverlayStore>((set) => ({
   selectedRentIndexItem: null,
   consumerIndexItem: null,
   subwayIndexItems: [],
+  selectedSubwayIndexItem: null,
   safetyIndexItems: [],
   selectedHomeRecommendationName: null,
   selectedHomeSubwayRanking: null,
@@ -126,8 +129,11 @@ export const useMapOverlayStore = create<MapOverlayStore>((set) => ({
     set({ rentIndexItems: [], selectedRentIndexItem: null }),
   setConsumerIndexItem: (item) => set({ consumerIndexItem: item }),
   clearConsumerIndexItem: () => set({ consumerIndexItem: null }),
-  setSubwayIndexItems: (items) => set({ subwayIndexItems: items }),
-  clearSubwayIndexItems: () => set({ subwayIndexItems: [] }),
+  setSubwayIndexItems: (items) =>
+    set({ subwayIndexItems: items, selectedSubwayIndexItem: null }),
+  selectSubwayIndexItem: (item) => set({ selectedSubwayIndexItem: item }),
+  clearSubwayIndexItems: () =>
+    set({ subwayIndexItems: [], selectedSubwayIndexItem: null }),
   setSafetyIndexItems: (items) => set({ safetyIndexItems: items }),
   clearSafetyIndexItems: () => set({ safetyIndexItems: [] }),
   selectHomeRecommendation: (name) =>


### PR DESCRIPTION
## 📌 Summary

- 커뮤니티 화면의 게시글 상세 패널 UI와 게시글 목록 필터링/표시 방식을 개선했습니다.
- 게시글 상세 패널에 닫기 헤더 추가
- 커뮤니티 탭 필터링 로직 수정
- 전체 탭 추가
- 게시글 카드 본문 미리보기 길이 제한

## 🔧 Changes

### 주요 변경 사항

- PostDetail에 작성/수정 모달과 동일한 형태의 상단 닫기 헤더 추가
- 상세 패널 본문 상단 여백을 헤더 구조에 맞게 조정
- 커뮤니티 탭에 전체 탭 추가
- 추천, 질문, 거주리뷰 탭 선택 시 post.category === activeTab인 게시글만 보이도록 필터링
- 전체 탭 선택 시 카테고리 필터 없이 모든 게시글 표시
- 동네 검색 필터가 카테고리 필터와 함께 동작하도록 유지
- PostCard의 게시글 본문을 line-clamp-2로 두 줄까지만 표시